### PR TITLE
Document more Kerberos CredGuard limitations

### DIFF
--- a/wiki/Usage.asciidoc
+++ b/wiki/Usage.asciidoc
@@ -129,8 +129,8 @@ Credential Guard may affect other commands that have not yet been identified.
 |===
 | Package    | Command                       | Effect
 | `kerberos` | `KerbChangePassword`          | Indirectly affected
-| `kerberos` | `RetrieveEncodedTicket        | Cannot get real TGT session key
-| `kerberos` | `RetrieveTicket               | Cannot get real TGT session key
+| `kerberos` | `RetrieveEncodedTicket`       | Cannot get real TGT session key
+| `kerberos` | `RetrieveTicket`              | Cannot get real TGT session key
 | `msv1_0`   | `MspGetCredentialKey`         | Prevented
 | `msv1_0`   | `MspLm20GetChallengeResponse` | Prevented
 | `msv1_0`   | `MspNtDeriveCredential`       | Prevented

--- a/wiki/Usage.asciidoc
+++ b/wiki/Usage.asciidoc
@@ -118,7 +118,7 @@ msv1_0 Lm20GetChallengeResponse ...
 
 LSA Whisperer may only be used to interact with the local machine due to the RPC security considerations outlined https://github.com/EvanMcBroom/lsa-whisperer/wiki#sspi-security[on the home page].
 The tool will also experience issues interacting with some SSPs (mainly cloudap) if it is ran as an AppContainer without certain capabilities.
-Partial documentation of these capabilities may be found on individual wiki pages but full documention is not provided as this is an unintended use case of the tool.
+Partial documentation of these capabilities may be found on individual wiki pages but full documentation is not provided as this is an unintended use case of the tool.
 
 The only additional limitation is when Credential Guard is enabled.
 Enabling Credential Guard is known to prevent certain commands as listed below.
@@ -129,6 +129,8 @@ Credential Guard may affect other commands that have not yet been identified.
 |===
 | Package    | Command                       | Effect
 | `kerberos` | `KerbChangePassword`          | Indirectly affected
+| `kerberos` | `RetrieveEncodedTicket        | Cannot get real TGT session key
+| `kerberos` | `RetrieveTicket               | Cannot get real TGT session key
 | `msv1_0`   | `MspGetCredentialKey`         | Prevented
 | `msv1_0`   | `MspLm20GetChallengeResponse` | Prevented
 | `msv1_0`   | `MspNtDeriveCredential`       | Prevented

--- a/wiki/sspi/kerberos.asciidoc
+++ b/wiki/sspi/kerberos.asciidoc
@@ -275,6 +275,7 @@ Implemented to allow the Winlogon session to refresh credentials as needed on te
 Get a ticket either by querying the ticket cache for the current logon session or by requesting the ticket from the current KDC.
 `SeTcbPrivilege` is required to specify another logon session.
 If the requested ticket is a TGT, `SeTcbPrivilege` is required to additionally get the session key for the TGT.
+If the TGT was obtained when Credential Guard was active, the returned TGT session key will not be valid, making the TGT unusable.
 
 ```
 kerberos RetrieveEncodedTicket --target-name {server name} [--luid {session id}] [--ticket-flags {value}] [--cache-option {value}] [--enc-type {type}]
@@ -292,6 +293,7 @@ kerberos RetrieveKeyTab --domain-name {name} --user-name {name} --password {pass
 
 Get the TGT from the ticket cache of the specified user logon session.
 `SeTcbPrivilege` is required to additionally get the session key for the TGT.
+If the TGT was obtained when Credential Guard was active, the returned TGT session key will not be valid, making the TGT unusable. 
 
 ```
 kerberos RetrieveTicket --target-name {server name} [--luid {session id}] [--ticket-flags {value}] [--cache-option {value}] [--enc-type {type}]


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request.
By explaining why you are making a change (or linking to an issue) and what changes you've made, you are helping to greatly speed up the review process.
-->

### Why:

Closes: N/A

Tested the behavior of a the `kerberos RetrieveEncodedTicket` and `kerberos RetrieveTicket` commands with and without Credential Guard enabled, found some undocumented limitations. 

<!-- If there is an existing issue for your change, please link to it above.
If there is _not_ an existing issue, please replace 'Closes:' with an explanation of what this PR does. -->

### What is being changed:
Add two entries to the `Credential Guard Limitations` table on the Usage page, and fix a typo  a few lines above the table. 

Add explanatory sentences to the two relevant sections on the `kerberos` documentation page

<!-- Let us know what you are changing. Please share anything that could provide the most context including code snippets, screenshots, or images.
-->

### Testing notes
Tested inside Microsoft's free deployment lab kit (https://learn.microsoft.com/en-us/microsoft-365/enterprise/modern-desktop-deployment-and-management-lab?view=o365-worldwide). Enabled and disabled CredGuard using the local GPO (steps here: https://learn.microsoft.com/en-us/windows/security/identity-protection/credential-guard/configure?tabs=gpo#configure-credential-guard-with-group-policy)

With CredGuard enabled, the output looks like this:
```
kerberos RetrieveEncodedTicket --target-name krbtgt/CORP.CONTOSO.COM
...
ServiceName         : krbtgt/CORP.CONTOSO.COM (Type 2)
TargetName          : krbtgt/CORP.CONTOSO.COM (Type 2)
ClientName          : CLIENT1$ (Type 1)
DomainName          : CORP.CONTOSO.COM
TargetDomainName    : CORP.CONTOSO.COM
AltTargetDomainName : CORP.CONTOSO.COM
SessionKey Type     : Aes256CtsHmacSha1_96
SessionKey Value[0xab]: ab0000000000000017000000640000000100000001010000010000006e0f01225ff2b5c1dad744aba2afdc12bb88602f2cda170178233c2658276fed2aa5a61adea8c71cf2287cb3832ae4b40100000000000000000000000000000001000000300000004b65726265726f734b6579576974684d657461646174610733fec465d4bcb69b01efd69e7f70ad028927bc16b91a63b80d11382b79bad00b4ce37236a9248796caf366615a3982
TicketFlags         : 1088487424
Flags               : 0
KeyExpirationTime   : 0
StartTime           : 133585568890000000
EndTime             : 133585928890000000
RenewUntil          : 133591616890000000
TimeSkew            : 0
EncodedTicket[0x653]: 7682064f3082064ba003020105a103020116a28204a33082049f6182049b30820497a003020105a1121b10434f52502e434f4e544f534f2e434f4da2253023a003020102a11c301a1b066b72627467741b10434f52502e434f4e544f534f2e434f4da38204533082044fa003020112a103020102a28204410482043db2a25a119b68f1c553ff41d1e828e1a8a9decf79a499cd9a839348508b3ce86f2a6592dbef45745f5c554d6d3919cb07fcaa4101a60ad552a5920d1ed3ef0c494a3bf5743ed874bcb523994aa931c72708742638efed3392fd93c957174d2f198ad874a23dcebdc0cfa1bbab3c68e19e48a22e5335c942c6dc0dd26368bfeaaeffd56d80efef831d4e2f1ce54fb4c81d6ae027cf197340ed4945284af98881e4f1ae466abd779d0042a05139138a4d82454f6395bdd2e3fb98560e61e359c0a1bfb59cef2dff8747c09a0b9fe2026c89587d16ed2a4704ce3542bf8f31abe2f411dfc2fcf89e88fae6cc31d5dadc953214b46129d40b0645b858e632c1991300fa3ae56ca2a5a81b16c78ca50b6432652ea3c233dc3e9202b47ba66d2b11d86d19fd5ea76906ecfdd0139bbe435093c69161db6235186ffca7a3d7bac69b8b6522961cb41f72c7dd725d87abc65ac550b0a6760b8ca6e882c9f4e4448ef3814ed16dda03467097f48f635c517c5fbf51492f3833be63d8a4da08bf7bd0e374da9fec818355d2fded9ec5231088dfc55318bcb243e289c7ff580321b8b91732b9f5cb5010c7cec554667d07ac7149f15e23018cfe1d2786b63204af72b4b4e88787b535bdbf03e2e221e92e4d1e480aa364cca28b64ebd9cde597de83fada45feda8b6e9fb303462b4273316e386ab6dc6a1d7470e8fa54482018b5689f86cd3d2d1cc2d11a2054e01a2e589fae9200176a95958f8f918ed1f248151ebe1d7c95a9866af34f4bafe4b5f8987cb1318d2d98a8c77a9e56ab14a256b7611ad1a680e4b0d88a1b4c003b3d2aa3b4a93609bf279eede43187a80c56c69c50f91b62d59b150e27ff5a19c51e330bb361d949e962a22016e975e261f54abf9d894b66d458d1d6f67bbf1205d424b66d931d3ee7c2b7ae481735184aac8f89f884a89c8e5fd17bb6232edf666ee02f043c5d778c0780dd952b9234d2983326c95057f64590bdf5d05627c1959b4b06485250732c53e8466c775e9d35f1cfc149f378dbcee74bce1f6aac51493113effaa95327bf24af70672d317c0cc217c64f87c9f0686d8f5c6c0ac6aa780985321812797f38b3288229f5e74e71e4f521436c88fcaf49527c23290da5576c672d218580586ac648753986ba61edf6f7d28a0742c1d40c88aeefef53875c46ceeec47305dbb215d1b2d61d72066b492d2ac4a0afb842ea564b613c829e6c222728843703264d9b0375856892b09f19424117c496341dfac0cdc8b9999d1d5bcc52282cf93fecba2a41f3207836b4e0fce2d465f7b4168d66ef167ad82d91dcac7c4621d806c43f5392771968acd44d2760b5fa3d949665be08e77b30402f564d8431964409258d882320f9e303c3f5010c245121e80e8968696e1bf437c5903692d47dff39a3d9308c313cef363f6f8c6e5b2252e1f404de9c063b26f53eb579345066d5928d208a434b731dcef91fce790c177a2c492d3b77c0a256e659c281a43e941f2c071d0003422109cb7c2182202330a382019630820192a003020100a2820189048201857d8201813082017da08201793082017530820171a081c63081c3a0040202ff4ca181ba0481b7575241500300000012000000ab0000000000000017000000640000000100000001010000010000006e0f01225ff2b5c1dad744aba2afdc12bb88602f2cda170178233c2658276fed2aa5a61adea8c71cf2287cb3832ae4b40100000000000000000000000000000001000000300000004b65726265726f734b6579576974684d657461646174610733fec465d4bcb69b01efd69e7f70ad028927bc16b91a63b80d11382b79bad00b4ce37236a9248796caf366615a3982a1121b10434f52502e434f4e544f534f2e434f4da2153013a003020101a10c300a1b08434c49454e543124a30703050040e10000a511180f32303234303432353232313434395aa611180f32303234303432363038313434395aa711180f32303234303530323232313434395aa8121b10434f52502e434f4e544f534f2e434f4da9253023a003020102a11c301a1b066b72627467741b10434f52502e434f4e544f534f2e434f4d
```
- Note the very long (invalid) `SessionKey Value`, which is copied into the `EncodedTicket` value, making it invalid/unusable as well. 

Running the same command with CredGuard disabled returns a much more reasonable (valid) `SessionKey`, and the resulting `EncodedTicket` value can be properly used with the usual tools:
```
kerberos RetrieveEncodedTicket --target-name krbtgt/CORP.CONTOSO.COM
...
ServiceName         : krbtgt/CORP.CONTOSO.COM (Type 2)
TargetName          : krbtgt/CORP.CONTOSO.COM (Type 2)
ClientName          : CLIENT1$ (Type 1)
DomainName          : CORP.CONTOSO.COM
TargetDomainName    : CORP.CONTOSO.COM
AltTargetDomainName : CORP.CONTOSO.COM
SessionKey Type     : Aes256CtsHmacSha1_96
SessionKey Value[0x20]: 0fefd146a47820fac6d618a414b1048d4daebcdcca03086cfd154d63a43560f6
TicketFlags         : 1088487424
Flags               : 0
KeyExpirationTime   : 0
StartTime           : 133585571650000000
EndTime             : 133585931650000000
RenewUntil          : 133591619650000000
TimeSkew            : 0
EncodedTicket[0x5ae]: 768205aa308205a6a003020105a103020116a28204a33082049f6182049b30820497a003020105a1121b10434f52502e434f4e544f534f2e434f4da2253023a003020102a11c301a1b066b72627467741b10434f52502e434f4e544f534f2e434f4da38204533082044fa003020112a103020102a28204410482043d5be38ac92cf8d7c9394ddb401abd3bf0754921f2aa49b58c5d14230678a25df6a5231de28f654e5893cd307374752f1f34560df4fd38af427749541004ab3464aa47dd126410ad794b96925f6b349639ab02063c8d7679a67de588f08049d618cefde05fd5b3545f21c720914a0c17c35a87e08030670702a0d439d6f43bf07f6a3119b387dd2be40c6accb49393ee2d31642ac35f50e234cdb0a805d809cd532c30edfe13661f3552381d18f9336b4de1e93b52128f46aad794d83d07b0725ba24e0a73ddfd6567a662c02a6485f6d581f5719b4f49bac79d038c3492883a9c7e8060187e3b08ea466ffec1c657e120cb22034d77d11902246afdbc3d4f1d99f75b85b6d96f14ee4b4abf3fa074fc324a08b973736e3719799b93ae5af739d61e13014beef6dc3bffdf147a52d0bec8eb310733e01e58410b4cd522ff74d8c3e09c6e7fe5afd23c5d9ee2149f5130a13e926fcd368d4e6cb9405a4658cb7f3bdfd7c5518ddedf85b947897a1a2ce6e295da8c031e7e9b445d265a6317c5608f22548c291d00862fc3c58da870b0f424c06b6654470fdd0500dd3d188055a34d8b9a46c866f2c058b41369cf566a2d7b4e672242497dbbb7676eb8545bdabda2f6ce6e072e3a2d97d001ea8dfbe686a828ec4990c154120fbecbe5e13723ca5f17931969e18422a4129471794436c7ae6b14f3c30dcc8fdfd129bb6134bdafc0af1bbb7d8963f93af39230cdc77f642bf3eec96e32543add8d28b16dba7040d699897af4159ebb3908568d65bd9a9d7cb1ee1a7a8046edf3f754102abb5eb83e89256124ff525a56ffc0e3d839dae331ff8ab44e6cda680e3ff77f8544d6787d06fc5d8e419d26d5f56252c753e8bbdbb1c3b17f06ad8cead2a687d0f12ae50fbc0600034ffd4a479ea3d44d2ab7446076d7be1ec4b388b4e618c9f3bb62306b774e06fee75a2910dee1e6b0ae6e7da1fc1c4e303925b9b4984b1c7cb04706f117765a83fc4c96691146686393a98bb57de4be6303ce28b8e51ddb1b8750c1105c1c8c51fdcceff734344e8c5635d96159e07b92d77ac71211a793db1640cc01641000d1bf7360877e232a0b82310637ea45393733f4abe7cf74eae85a4214b56ddb297fc327b2aa019f000f6490e670bb931864c90ed2c47b3cf5e9b2698de00c4d815f49c673d12a3218d27e89e39eba8ec731ad5772496d19c6a5260eab767725a196b7d599f524e57d0f5281a50f72741e53298747e1075f69f4b2de4aa6a05e87fbf578e6488a2be80a15e4703b027ba6f6256315554137c5ac0eafe1e48dbb1e33e93169510cfc529377b377b38e5e6713715a2316fea54c819bba8afc7bc0fc965e932be79eb49ac45bbfd781a8811c3e81cbdcd7de0b1d6fdf64ce75a3ca5d1fc6d0368db20f0b8806e09aafeb01a5eef651520621024306404fbdc592f42719c3b26304e6fff6b8b3a45a224632c4c30de76d5e7d6b19dd0ae9fce24bc070a24358dd104503e134907ce0a412aca50f2ae7803ba4619b1eb7a381f23081efa003020100a281e70481e47d81e13081dea081db3081d83081d5a02b3029a003020112a12204200fefd146a47820fac6d618a414b1048d4daebcdcca03086cfd154d63a43560f6a1121b10434f52502e434f4e544f534f2e434f4da2153013a003020101a10c300a1b08434c49454e543124a30703050040e10000a511180f32303234303432353232313932355aa611180f32303234303432363038313932355aa711180f32303234303530323232313932355aa8121b10434f52502e434f4e544f534f2e434f4da9253023a003020102a11c301a1b066b72627467741b10434f52502e434f4e544f534f2e434f4d
```

Same behavior is observed when running the `kerberos RetrieveTicket` command. Specifying a `--luid` for a logged-in domain user also has the same behavior for both commands. 

I'm pretty sure the invalid `SessionKey` data being returned is the encrypted blob that only CredGuard can decrypt, described here: https://syfuhs.net/how-windows-defender-credential-guard-works
> The one thing it doesn't return to LSA is the TGT session key. Or rather, it returns the session key but encrypted to a key only known to Cred Guard, so if someone could steal the blob out of memory it'd be useless.