### PR TITLE
Adding a build GitHub Action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,10 @@
+name: Build LSA Whisperer
+on:
+  workflow_dispatch: # Allows you to manually run the workflow
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v2
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,5 +22,5 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: packages
-        path: builds/**
+        path: builds/Debug/**
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
       with:
         submodules: recursive
     - name: Prepare the build
-      run: cmake .. -A x64
+      run: cmake .. -A x64 -DCMAKE_SYSTEM_VERSION=10.0.22621.0
       working-directory: builds
     - name: Run the build
       run: cmake --build .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,4 +7,9 @@ jobs:
     steps:
     - name: Checkout repo
       uses: actions/checkout@v2
-
+    - name: Prepare the build
+      run: cmake .. -A x64
+      working-directory: builds
+    - name: Run the build
+      run: cmake --build .
+      working-directory: builds

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,9 @@
 name: Build LSA Whisperer
 on:
   workflow_dispatch: # Allows you to manually run the workflow
+  push:
+    branches: ['master']
+    paths: ['cmake/**', 'include/**', 'libraries/**', 'source/**', 'CMakeList.txt']
 jobs:
   build:
     runs-on: windows-latest
@@ -15,3 +18,9 @@ jobs:
     - name: Run the build
       run: cmake --build .
       working-directory: builds
+    - name: Upload artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: packages
+        path: builds/**
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,9 @@ jobs:
     runs-on: windows-latest
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
+      with:
+        submodules: recursive
     - name: Prepare the build
       run: cmake .. -A x64
       working-directory: builds


### PR DESCRIPTION
### Why:

* Sometimes you don't have access to a development environment where to build the project, and need a quick access to a compiled build of the tools.
* To enhance the project by making sure that compile-time issues can be spotted.

### What is being changed:

Added a very simple GitHub action job that builds the project using the default `latest-windows` image and uploads resulting artifacts to the job.